### PR TITLE
Apply fabbot.io coding standard patch.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RouterDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RouterDataCollectorTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
 use PHPUnit\Framework\TestCase;
@@ -16,7 +25,7 @@ class RouterDataCollectorTest extends TestCase
     {
         $collector = new RouterDataCollector();
 
-        $request  = Request::create('http://test.com/foo?bar=baz');
+        $request = Request::create('http://test.com/foo?bar=baz');
         $response = new RedirectResponse('http://test.com/redirect');
 
         $event = $this->createControllerEvent($request);
@@ -33,7 +42,7 @@ class RouterDataCollectorTest extends TestCase
     {
         $collector = new RouterDataCollector();
 
-        $request  = Request::create('http://test.com/foo?bar=baz');
+        $request = Request::create('http://test.com/foo?bar=baz');
         $response = new Response('test');
 
         $event = $this->createControllerEvent($request);
@@ -51,9 +60,9 @@ class RouterDataCollectorTest extends TestCase
         $collector = new RouterDataCollector();
 
         // Fill Collector
-        $request  = Request::create('http://test.com/foo?bar=baz');
+        $request = Request::create('http://test.com/foo?bar=baz');
         $response = new RedirectResponse('http://test.com/redirect');
-        $event    = $this->createControllerEvent($request);
+        $event = $this->createControllerEvent($request);
         $collector->onKernelController($event);
         $collector->collect($request, $response);
 


### PR DESCRIPTION
I noticed your `symfony/symfony` [PR request](https://github.com/symfony/symfony/pull/48848) was stuck due to some required coding standard fixes.

See:

https://fabbot.io/report/symfony/symfony/48848/42801fd8c2714a37fa2ee1e5eebbe8d7a5992d6e

This PR applies those changes requested by `fabbot.io`.
